### PR TITLE
Optimization of loading time for large repositories

### DIFF
--- a/src/GitExtensions.SolutionRunner/GitExtensions.SolutionRunner.csproj
+++ b/src/GitExtensions.SolutionRunner/GitExtensions.SolutionRunner.csproj
@@ -22,6 +22,9 @@
   
   <!-- Reference to GitExtensions dlls. -->
   <ItemGroup>
+    <Reference Include="GitExtUtils">
+      <HintPath>..\..\references\GitExtensions\GitExtUtils.dll</HintPath>
+    </Reference>
     <Reference Include="GitUI">
       <HintPath>..\..\references\GitExtensions\GitUI.dll</HintPath>
     </Reference>

--- a/src/GitExtensions.SolutionRunner/Plugin.cs
+++ b/src/GitExtensions.SolutionRunner/Plugin.cs
@@ -69,7 +69,7 @@ namespace GitExtensions.SolutionRunner
                 MenuStripEx mainMenu = FindMainMenu(commands);
                 if (mainMenu != null && FindMainMenuItem(commands, mainMenu) == null)
                 {
-                    var provider = new DirectorySolutionFileProvider(commands.GitModule.WorkingDir);
+                    var provider = new GitSolutionFileProvider(commands.GitModule.WorkingDir, commands.GitModule.GitExecutable);
 
                     mainMenu.Items.Add(new SolutionListMenuItem(provider, Configuration));
                 }

--- a/src/GitExtensions.SolutionRunner/Services/GitSolutionFileProvider.cs
+++ b/src/GitExtensions.SolutionRunner/Services/GitSolutionFileProvider.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using GitUIPluginInterfaces;
+using System.Linq;
+
+namespace GitExtensions.SolutionRunner.Services
+{
+    public class GitSolutionFileProvider : ISolutionFileProvider
+    {
+        private readonly string rootPath;
+        private readonly IExecutable executor;
+
+        public GitSolutionFileProvider(string rootPath, IExecutable executor)
+        {
+            this.rootPath = rootPath;
+            this.executor = executor;
+        }
+
+        public async Task<IReadOnlyCollection<string>> GetListAsync(bool isTopLevelSearchOnly)
+        {
+            IProcess process = executor.Start("ls-files -coz -- *.sln", redirectOutput: true);
+            string output = await process.StandardOutput.ReadToEndAsync();
+
+            var result = output.Split(new[] { '\0' }, System.StringSplitOptions.RemoveEmptyEntries)
+                .Where(x => !isTopLevelSearchOnly || !x.Contains('/'))
+                .Select(x => Path.Combine(rootPath, x))
+                .Where(File.Exists)
+                .ToArray();
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #11 Optimize loading time

Added usage `git ls-files -coz -- *.sln` for finding solutions instead of searching files on disk.