### PR TITLE
Specify output encoding

### DIFF
--- a/src/GitExtensions.SolutionRunner/Services/GitSolutionFileProvider.cs
+++ b/src/GitExtensions.SolutionRunner/Services/GitSolutionFileProvider.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using GitUIPluginInterfaces;
 using System.Linq;
+using System.Text;
 
 namespace GitExtensions.SolutionRunner.Services
 {
@@ -19,7 +20,7 @@ namespace GitExtensions.SolutionRunner.Services
 
         public async Task<IReadOnlyCollection<string>> GetListAsync(bool isTopLevelSearchOnly)
         {
-            IProcess process = executor.Start("ls-files -coz -- *.sln", redirectOutput: true);
+            IProcess process = executor.Start("ls-files -coz -- *.sln", redirectOutput: true, outputEncoding: Encoding.Default);
             string output = await process.StandardOutput.ReadToEndAsync();
 
             var result = output.Split(new[] { '\0' }, System.StringSplitOptions.RemoveEmptyEntries)


### PR DESCRIPTION
to prevent error popup
https://github.com/gitextensions/gitextensions/blob/14e881406bd69ed6cd279906b849ccb342443f5b/GitCommands/Git/Executable.cs#L74
that make it unusable (because that close the menu item)