### PR TITLE
Fixed search performance

### DIFF
--- a/src/GitExtensions.SolutionRunner/Services/GitSolutionFileProvider.cs
+++ b/src/GitExtensions.SolutionRunner/Services/GitSolutionFileProvider.cs
@@ -20,15 +20,9 @@ namespace GitExtensions.SolutionRunner.Services
 
         public async Task<IReadOnlyCollection<string>> GetListAsync(bool isTopLevelSearchOnly, bool includeWorkspaces)
         {
-            IProcess process = executor.Start("ls-files -coz -- *.sln", redirectOutput: true, outputEncoding: Encoding.Default);
+            string command = "ls-files -cz *.sln" + (includeWorkspaces ? " *.code-workspace" : "");
+            IProcess process = executor.Start(command, redirectOutput: true, outputEncoding: Encoding.Default);
             string output = await process.StandardOutput.ReadToEndAsync();
-
-            if (includeWorkspaces)
-            {
-                process = this.executor.Start("ls-files -coz -- *.code-workspace", redirectOutput: true, outputEncoding: Encoding.Default);
-                output += '\0';
-                output += await process.StandardOutput.ReadToEndAsync();
-            }
 
             var result = output.Split(new[] { '\0' }, System.StringSplitOptions.RemoveEmptyEntries)
                 .Where(x => !isTopLevelSearchOnly || !x.Contains('/'))


### PR DESCRIPTION
* excluded other/untracked files (removed -o flag (Shows other (i.e. untracked) files in the output)) [ref](https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-ls-files.html)
* use one query for both patterns

for my work repo (many files and many solutions) this change helps to speed up from 5 secs to less that 1 sec! yay!