### PR TITLE
Fix VSCode workspaces start

### DIFF
--- a/src/GitExtensions.SolutionRunner/UI/SolutionItemMenuItem.cs
+++ b/src/GitExtensions.SolutionRunner/UI/SolutionItemMenuItem.cs
@@ -28,7 +28,9 @@ namespace GitExtensions.SolutionRunner.UI
                 ?.Replace(PluginSettings.SolutionDirectoryToken, Path.GetDirectoryName(filePath));
 
             var process = new Process();
-            process.StartInfo.FileName = settings.ExecutablePath ?? filePath; 
+            process.StartInfo.FileName = !string.IsNullOrWhiteSpace(settings.ExecutablePath)
+                ? settings.ExecutablePath
+                : filePath;
             process.StartInfo.Arguments = arguments ?? filePath;
             process.StartInfo.UseShellExecute = true;
 


### PR DESCRIPTION
Replace null check with whitespace check.
In new versions `settings.ExecutablePath` is empty string by default.

![settings](https://github.com/maraf/GitExtensions.SolutionRunner/assets/11049459/30565203-46da-49cb-8dd9-b66623fdf00b)
![debug1](https://github.com/maraf/GitExtensions.SolutionRunner/assets/11049459/053ceb16-82c4-43c7-90d7-e300405f8253)
![debug2](https://github.com/maraf/GitExtensions.SolutionRunner/assets/11049459/3bbb8df4-3f01-4dde-86e4-133d461865d0)
