### PR TITLE
Add support for the new solution file format (slnx).

### DIFF
--- a/src/GitExtensions.SolutionRunner/Services/DirectorySolutionFileProvider.cs
+++ b/src/GitExtensions.SolutionRunner/Services/DirectorySolutionFileProvider.cs
@@ -17,7 +17,7 @@ namespace GitExtensions.SolutionRunner.Services
         public Task<IReadOnlyCollection<string>> GetListAsync(bool isTopLevelSearchOnly, bool includeWorkspaces)
         {
             SearchOption searchOption = isTopLevelSearchOnly ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
-            string[] solutionFiles = Directory.GetFiles(rootPath, "*.sln", searchOption);
+            string[] solutionFiles = Directory.GetFiles(rootPath, "*.sln?", searchOption);
 
             if (includeWorkspaces) 
             {


### PR DESCRIPTION
slnx is the successor of sln files, with VS 2022 17.14 it will be out of beta and its already supported by the .net 9 sdk.
JetBrains Rider and VSCode also support slnx files (maybe not all nuances).

For details check: https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/